### PR TITLE
fix: deprecation

### DIFF
--- a/src/Qbil/Models/Supplier.php
+++ b/src/Qbil/Models/Supplier.php
@@ -211,7 +211,7 @@ class Supplier implements \JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_reduce(
             array_keys($supplier = get_object_vars($this)),


### PR DESCRIPTION
> Deprecated: Return type of Qbil\ReadSoftOnline\Models\Supplier::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/asrar/Desktop/qbil-trade/vendor/qbil-software/read-soft-online/src/Qbil/Models/Supplier.php on line 214